### PR TITLE
feat: add edge roam and sparse browser media fallback

### DIFF
--- a/gnome-extension/mochi-typing@miflow13/extension.js
+++ b/gnome-extension/mochi-typing@miflow13/extension.js
@@ -98,7 +98,29 @@ const USER_IDLE_AFTER_MS = 120_000;
 const POLL_INTERVAL_MS = 50;
 const EVENT_TIME_EPSILON_MS = 12;
 const VIDEO_FOCUS_HEARTBEAT_MS = 1_000;
-const BROWSER_MARKERS = ['google-chrome', 'chromium', 'chrome', 'firefox'];
+const BROWSER_MARKERS = [
+    'google-chrome',
+    'com.google.chrome',
+    'chromium',
+    'chrome',
+    'firefox',
+    'mozilla.firefox',
+    'brave',
+    'vivaldi',
+    'microsoft-edge',
+    'microsoft.edge',
+    'msedge',
+];
+const BROWSER_TITLE_NAMES = [
+    'google chrome',
+    'chromium',
+    'chrome',
+    'mozilla firefox',
+    'firefox',
+    'brave',
+    'vivaldi',
+    'microsoft edge',
+];
 
 export default class MochiTypingActivityExtension extends Extension {
     enable() {
@@ -157,6 +179,7 @@ export default class MochiTypingActivityExtension extends Extension {
             VIDEO_FOCUS_HEARTBEAT_MS,
             () => {
                 this._updateYouTubeFocusedState(true);
+                this._updateAppCategory();
                 return GLib.SOURCE_CONTINUE;
             },
         );
@@ -278,7 +301,7 @@ export default class MochiTypingActivityExtension extends Extension {
         if (matches(TERMINAL_MARKERS))
             return 'terminal';
         if (matches(BROWSER_MARKERS))
-            return 'browser';
+            return this._isFocusedYouTubeWindow(window) ? 'media' : 'browser';
         if (matches(MEDIA_APP_MARKERS))
             return 'media';
         return 'unknown';
@@ -374,23 +397,37 @@ export default class MochiTypingActivityExtension extends Extension {
         if (!isBrowser)
             return false;
 
-        // Chrome's MPRIS session does not expose the page URL on this system.
-        // Inspect the focused window title only long enough to reduce it to a
-        // boolean. Never retain or transmit the title.
+        // Browser MPRIS data often omits the page URL. Inspect the focused title
+        // only long enough to reduce it to a boolean; the raw title is never
+        // logged, retained, or sent over D-Bus.
         let title = '';
         try {
-            title = String(window.get_title() ?? '').toLowerCase();
+            title = String(window.get_title() ?? '').trim().toLowerCase();
         } catch (_error) {
             return false;
         }
 
-        // Treat only a YouTube-style video/page title as YouTube context.
-        // A plain substring check was too broad: unrelated browser tabs whose
-        // titles merely mentioned "YouTube" could produce false WATCHING
-        // transitions when Chromium still had an MPRIS Playing session.
+        if (title.includes('youtube music'))
+            return false;
+
+        // Chrome/Chromium/Firefox can append their own application name after
+        // the page title, e.g. "Video - YouTube - Google Chrome". Strip only a
+        // known browser suffix, then require YouTube to be the page-brand suffix.
+        for (const browserName of BROWSER_TITLE_NAMES) {
+            for (const separator of [' - ', ' – ', ' — ']) {
+                const suffix = `${separator}${browserName}`;
+                if (title.endsWith(suffix)) {
+                    title = title.slice(0, -suffix.length).trim();
+                    break;
+                }
+            }
+        }
+
         return (
-            title.endsWith(' - youtube') &&
-            !title.includes('youtube music')
+            title.endsWith(' - youtube') ||
+            title.endsWith(' – youtube') ||
+            title.endsWith(' — youtube') ||
+            title === 'youtube'
         );
     }
 

--- a/src/mochi/config.py
+++ b/src/mochi/config.py
@@ -99,6 +99,20 @@ class ConfigStore:
         self._save(data)
         self._logger.debug("Stay put: %s", bool(enabled))
 
+    def load_edge_roam(self) -> bool:
+        """Return whether autonomous wandering should stay on screen edges."""
+        try:
+            edge_roam = self._load()["edge_roam"]
+        except (FileNotFoundError, KeyError, TypeError, ValueError, json.JSONDecodeError):
+            return False
+        return edge_roam if isinstance(edge_roam, bool) else False
+
+    def save_edge_roam(self, enabled: bool) -> None:
+        data = self._load_or_empty()
+        data["edge_roam"] = bool(enabled)
+        self._save(data)
+        self._logger.debug("Edge roam: %s", bool(enabled))
+
     def reset_position(self) -> None:
         try:
             data = self._load()

--- a/src/mochi/edge_roam.py
+++ b/src/mochi/edge_roam.py
@@ -1,0 +1,206 @@
+"""Perimeter-only autonomous walking for Mochi's Edge roam mode."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import math
+
+from mochi.behavior import WalkMotion
+from mochi.config import Position
+
+
+@dataclass(frozen=True, slots=True)
+class EdgeBounds:
+    left: int
+    right: int
+    top: int
+    bottom: int
+
+    @property
+    def width(self) -> int:
+        return max(0, self.right - self.left)
+
+    @property
+    def height(self) -> int:
+        return max(0, self.bottom - self.top)
+
+    @property
+    def perimeter(self) -> int:
+        return 2 * (self.width + self.height)
+
+
+def bounds_for_placement(placement, origin: Position) -> EdgeBounds | None:
+    """Return the same safe monitor bounds used by WindowPlacement.clamp_position."""
+    monitor = placement._monitor_for_position(origin.x, origin.y)
+    if monitor is None:
+        return None
+
+    geometry = monitor.get_geometry()
+    width, height = placement.window.get_default_size()
+    edge_padding = placement.EDGE_PADDING_PX
+    bottom_padding = placement.BOTTOM_PADDING_PX
+
+    if placement.layer_shell_enabled:
+        left = geometry.x + edge_padding
+        right = geometry.x + max(edge_padding, geometry.width - width - edge_padding)
+        top = bottom_padding
+        bottom = max(bottom_padding, geometry.height - height - edge_padding)
+    else:
+        scale = placement._x11_coordinate_scale()
+        left = round((geometry.x + edge_padding) * scale)
+        right = round(
+            (
+                geometry.x
+                + max(edge_padding, geometry.width - width - edge_padding)
+            )
+            * scale
+        )
+        top = round((geometry.y + edge_padding) * scale)
+        bottom = round(
+            (
+                geometry.y
+                + max(edge_padding, geometry.height - height - bottom_padding)
+            )
+            * scale
+        )
+
+    return EdgeBounds(round(left), round(right), round(top), round(bottom))
+
+
+def nearest_edge_point(origin: Position, bounds: EdgeBounds) -> Position:
+    """Project a point to the nearest safe edge without changing monitors."""
+    x = max(bounds.left, min(origin.x, bounds.right))
+    y = max(bounds.top, min(origin.y, bounds.bottom))
+    distances = (
+        (abs(y - bounds.top), Position(x, bounds.top)),
+        (abs(x - bounds.right), Position(bounds.right, y)),
+        (abs(y - bounds.bottom), Position(x, bounds.bottom)),
+        (abs(x - bounds.left), Position(bounds.left, y)),
+    )
+    return min(distances, key=lambda item: item[0])[1]
+
+
+def _perimeter_coordinate(point: Position, bounds: EdgeBounds) -> float:
+    """Map a perimeter point to clockwise distance from the top-left corner."""
+    x = max(bounds.left, min(point.x, bounds.right))
+    y = max(bounds.top, min(point.y, bounds.bottom))
+    w = bounds.width
+    h = bounds.height
+
+    if y == bounds.top and x < bounds.right:
+        return float(x - bounds.left)
+    if x == bounds.right and y < bounds.bottom:
+        return float(w + y - bounds.top)
+    if y == bounds.bottom and x > bounds.left:
+        return float(w + h + bounds.right - x)
+    return float(2 * w + h + bounds.bottom - y)
+
+
+def _point_at_perimeter(distance: float, bounds: EdgeBounds) -> Position:
+    perimeter = bounds.perimeter
+    if perimeter <= 0:
+        return Position(bounds.left, bounds.top)
+
+    distance %= perimeter
+    w = bounds.width
+    h = bounds.height
+    if distance < w:
+        return Position(round(bounds.left + distance), bounds.top)
+    distance -= w
+    if distance < h:
+        return Position(bounds.right, round(bounds.top + distance))
+    distance -= h
+    if distance < w:
+        return Position(round(bounds.right - distance), bounds.bottom)
+    distance -= w
+    return Position(bounds.left, round(bounds.bottom - distance))
+
+
+@dataclass(frozen=True, slots=True)
+class EdgeWalkMotion:
+    """WalkMotion-compatible path that follows the rectangular screen perimeter."""
+
+    origin: tuple[int, int]
+    target: tuple[int, int]
+    bounds: EdgeBounds
+    start_coordinate: float
+    travel_distance: float
+    clockwise: bool
+    cycle_duration_ms: int
+    speed_px_per_second: float = 72.0
+
+    @property
+    def distance(self) -> float:
+        return self.travel_distance
+
+    @property
+    def pixels_per_cycle(self) -> float:
+        return self.speed_px_per_second * self.cycle_duration_ms / 1_000
+
+    @property
+    def cycles(self) -> int:
+        return max(1, round(self.distance / self.pixels_per_cycle))
+
+    @property
+    def duration_ms(self) -> int:
+        return self.cycles * self.cycle_duration_ms
+
+    def progress(self, elapsed_ms: int) -> float:
+        return min(1.0, max(0.0, elapsed_ms / self.duration_ms))
+
+    def eased_progress(self, elapsed_ms: int) -> float:
+        progress = self.progress(elapsed_ms)
+        return progress * progress * (3.0 - 2.0 * progress)
+
+    def position_at(self, elapsed_ms: int) -> tuple[int, int]:
+        travelled = self.travel_distance * self.eased_progress(elapsed_ms)
+        direction = 1.0 if self.clockwise else -1.0
+        point = _point_at_perimeter(
+            self.start_coordinate + direction * travelled,
+            self.bounds,
+        )
+        return point.x, point.y
+
+    def animation_progress(self, elapsed_ms: int) -> float:
+        travelled = self.travel_distance * self.eased_progress(elapsed_ms)
+        return (travelled / self.pixels_per_cycle) % 1.0
+
+
+def build_edge_roam_motion(
+    placement,
+    origin: Position,
+    *,
+    travel_distance: float,
+    clockwise: bool,
+    cycle_duration_ms: int,
+    speed_px_per_second: float,
+):
+    """Build a walk to the nearest edge, or a perimeter-following walk once there."""
+    bounds = bounds_for_placement(placement, origin)
+    if bounds is None or bounds.perimeter <= 0:
+        return None
+
+    edge_origin = nearest_edge_point(origin, bounds)
+    approach_distance = math.hypot(edge_origin.x - origin.x, edge_origin.y - origin.y)
+    if approach_distance > 1.0:
+        return WalkMotion(
+            origin=(origin.x, origin.y),
+            target=(edge_origin.x, edge_origin.y),
+            cycle_duration_ms=cycle_duration_ms,
+            speed_px_per_second=speed_px_per_second,
+        )
+
+    start = _perimeter_coordinate(edge_origin, bounds)
+    travel = max(WalkMotion.MIN_DISTANCE, float(travel_distance))
+    direction = 1.0 if clockwise else -1.0
+    target = _point_at_perimeter(start + direction * travel, bounds)
+    return EdgeWalkMotion(
+        origin=(edge_origin.x, edge_origin.y),
+        target=(target.x, target.y),
+        bounds=bounds,
+        start_coordinate=start,
+        travel_distance=travel,
+        clockwise=clockwise,
+        cycle_duration_ms=cycle_duration_ms,
+        speed_px_per_second=speed_px_per_second,
+    )

--- a/src/mochi/media_activity.py
+++ b/src/mochi/media_activity.py
@@ -1,8 +1,9 @@
 """Privacy-conscious media activity detection for Mochi.
 
-Mochi uses MPRIS for playback state and the optional GNOME Shell companion
-extension for a privacy-reduced "YouTube is focused" boolean. Metadata is
-inspected transiently and is never retained, logged, or exposed elsewhere.
+Mochi uses MPRIS for playback state plus coarse GNOME Shell focus signals.
+Metadata is inspected transiently and is never retained, logged, or exposed.
+When Chromium omits URL/site metadata, focused-browser state can safely act as
+the final fallback for an already-playing browser MPRIS session.
 """
 
 from __future__ import annotations
@@ -36,7 +37,7 @@ _BROWSER_PLAYER_MARKERS = (
 
 
 class MprisMediaBackend:
-    """Read a minimal boolean watchable-video signal from MPRIS."""
+    """Read a minimal boolean watchable-media signal from MPRIS."""
 
     name = "MPRIS media playback"
     DBUS_NAME = "org.freedesktop.DBus"
@@ -51,14 +52,19 @@ class MprisMediaBackend:
     ACTIVITY_INTERFACE_NAME = "io.github.mochi_desktop.Mochi.TypingMonitor"
     YOUTUBE_FOCUSED_STARTED_SIGNAL = "YouTubeFocusedStarted"
     YOUTUBE_FOCUSED_STOPPED_SIGNAL = "YouTubeFocusedStopped"
+    APP_CATEGORY_SIGNAL = "AppCategoryChanged"
 
     def __init__(self) -> None:
         self._connection = None
         self._youtube_focused = False
+        self._focused_browser = False
         self._watching_via_youtube_focus = False
+        self._watching_via_browser_focus = False
         self._on_youtube_focus_changed: Callable[[bool], None] | None = None
+        self._on_browser_focus_changed: Callable[[bool], None] | None = None
         self._youtube_focus_started_subscription_id: int | None = None
         self._youtube_focus_stopped_subscription_id: int | None = None
+        self._app_category_subscription_id: int | None = None
         self.last_error: str | None = None
 
     @property
@@ -69,10 +75,23 @@ class MprisMediaBackend:
     def watching_via_youtube_focus(self) -> bool:
         return self._watching_via_youtube_focus
 
+    @property
+    def watching_via_browser_focus(self) -> bool:
+        return self._watching_via_browser_focus
+
     def set_youtube_focus_changed_callback(
         self, callback: Callable[[bool], None] | None
     ) -> None:
         self._on_youtube_focus_changed = callback
+
+    def set_browser_focus_changed_callback(
+        self, callback: Callable[[bool], None] | None
+    ) -> None:
+        self._on_browser_focus_changed = callback
+
+    def set_focused_browser(self, active: bool) -> None:
+        """Receive only whether the coarse focused-app category is a browser."""
+        self._focused_browser = bool(active)
 
     @staticmethod
     def _load_gio():
@@ -91,14 +110,14 @@ class MprisMediaBackend:
             if self._connection is None:
                 self.last_error = "session D-Bus connection is unavailable"
                 return False
-            self._subscribe_youtube_focus()
+            self._subscribe_focus_signals()
         except Exception as exc:
             self.last_error = f"{type(exc).__name__}: {exc}"
             self._connection = None
             return False
         return True
 
-    def _subscribe_youtube_focus(self) -> None:
+    def _subscribe_focus_signals(self) -> None:
         connection = self._connection
         if connection is None or not hasattr(connection, "signal_subscribe"):
             return
@@ -124,16 +143,29 @@ class MprisMediaBackend:
                 flags,
                 self._on_youtube_focused_stopped,
             )
+            category_id = connection.signal_subscribe(
+                self.ACTIVITY_BUS_NAME,
+                self.ACTIVITY_INTERFACE_NAME,
+                self.APP_CATEGORY_SIGNAL,
+                self.ACTIVITY_OBJECT_PATH,
+                None,
+                flags,
+                self._on_app_category_changed,
+            )
             self._youtube_focus_started_subscription_id = (
                 int(started_id) if started_id else None
             )
             self._youtube_focus_stopped_subscription_id = (
                 int(stopped_id) if stopped_id else None
             )
+            self._app_category_subscription_id = (
+                int(category_id) if category_id else None
+            )
         except Exception:
             # Metadata-only detection can still operate without the Shell helper.
             self._youtube_focus_started_subscription_id = None
             self._youtube_focus_stopped_subscription_id = None
+            self._app_category_subscription_id = None
 
     def _on_youtube_focused_started(self, *_ignored) -> None:
         changed = not self._youtube_focused
@@ -147,6 +179,26 @@ class MprisMediaBackend:
         if changed and self._on_youtube_focus_changed is not None:
             self._on_youtube_focus_changed(False)
 
+    def _on_app_category_changed(
+        self,
+        _connection,
+        _sender_name,
+        _object_path,
+        _interface_name,
+        _signal_name,
+        parameters,
+    ) -> None:
+        try:
+            unpacked = _deep_unpack(parameters)
+            category = unpacked[0] if isinstance(unpacked, tuple) else unpacked
+        except Exception:
+            return
+        active = category == "browser"
+        changed = active != self._focused_browser
+        self._focused_browser = active
+        if changed and self._on_browser_focus_changed is not None:
+            self._on_browser_focus_changed(active)
+
     def stop(self) -> None:
         if self._connection is not None and hasattr(
             self._connection, "signal_unsubscribe"
@@ -154,6 +206,7 @@ class MprisMediaBackend:
             for subscription_id in (
                 self._youtube_focus_started_subscription_id,
                 self._youtube_focus_stopped_subscription_id,
+                self._app_category_subscription_id,
             ):
                 if subscription_id is None:
                     continue
@@ -164,8 +217,11 @@ class MprisMediaBackend:
 
         self._youtube_focus_started_subscription_id = None
         self._youtube_focus_stopped_subscription_id = None
+        self._app_category_subscription_id = None
         self._youtube_focused = False
+        self._focused_browser = False
         self._watching_via_youtube_focus = False
+        self._watching_via_browser_focus = False
         self._connection = None
 
     def sample_youtube_playing(self) -> bool | None:
@@ -196,6 +252,8 @@ class MprisMediaBackend:
         if not isinstance(names, (list, tuple)):
             return False
 
+        self._watching_via_youtube_focus = False
+        self._watching_via_browser_focus = False
         sampled_player = False
         player_error = False
 
@@ -236,28 +294,38 @@ class MprisMediaBackend:
 
         # Local/direct video files are playback-driven, not focus-driven.
         if _metadata_indicates_video_file(metadata):
-            self._watching_via_youtube_focus = False
             return True
 
         youtube_metadata = _metadata_indicates_youtube(metadata)
 
-        # Browser YouTube represents the user's active viewing context.
-        # Requiring the Shell's boolean focus signal lets tabbing away stop
-        # WATCHING even if playback continues in the background.
+        # Browser YouTube is focus-sensitive so background playback does not
+        # make Mochi behave as though the user is actively watching it.
         if youtube_metadata and is_browser:
-            self._watching_via_youtube_focus = True
-            return self._youtube_focused
+            if self._youtube_focused:
+                self._watching_via_youtube_focus = True
+                return True
+            if self._focused_browser:
+                self._watching_via_browser_focus = True
+                return True
+            return False
 
         # Non-browser players that explicitly identify YouTube can use metadata.
         if youtube_metadata:
-            self._watching_via_youtube_focus = False
             return True
 
-        # Chromium-family browsers frequently omit page URL/art metadata.
-        # Active browser playback + the privacy-reduced focused-YouTube signal
-        # is the intended fallback.
+        # Preferred sparse-metadata fallback: the Shell already reduced the
+        # focused page to a YouTube boolean.
         if self._youtube_focused and is_browser:
             self._watching_via_youtube_focus = True
+            return True
+
+        # Chromium on Fedora commonly exposes exactly what playerctl reports:
+        # a browser MPRIS player in Playing state, a media title, and no URL or
+        # site branding. If that browser is also the coarse focused-app category,
+        # treat it as focused browser media. No title, URL, or page content is
+        # retained or transmitted to make this decision.
+        if self._focused_browser and is_browser:
+            self._watching_via_browser_focus = True
             return True
 
         return False
@@ -281,7 +349,7 @@ class MprisMediaBackend:
 
 
 class MediaActivityMonitor:
-    """Turn MPRIS samples into stable YouTube start/stop events."""
+    """Turn privacy-reduced MPRIS/focus samples into stable media events."""
 
     POLL_INTERVAL_MS = 1_000
     STOP_GRACE_SECONDS = 5.0
@@ -302,6 +370,10 @@ class MediaActivityMonitor:
         if hasattr(self._backend, "set_youtube_focus_changed_callback"):
             self._backend.set_youtube_focus_changed_callback(
                 self._on_youtube_focus_changed
+            )
+        if hasattr(self._backend, "set_browser_focus_changed_callback"):
+            self._backend.set_browser_focus_changed_callback(
+                self._on_browser_focus_changed
             )
         self._clock = clock
         self._source_id: int | None = None
@@ -353,9 +425,33 @@ class MediaActivityMonitor:
         self.youtube_playing = False
         self._last_playing_at = None
 
+    def _on_browser_focus_changed(self, active: bool) -> None:
+        if not self.available:
+            return
+
+        self._logger.debug(
+            "Focused browser media fallback: %s",
+            "active" if active else "inactive",
+        )
+
+        if active:
+            self._poll()
+            return
+
+        if (
+            self.youtube_playing
+            and bool(getattr(self._backend, "watching_via_browser_focus", False))
+        ):
+            self._stop_watching_now("browser focus lost")
+
     def _on_youtube_focus_changed(self, active: bool) -> None:
         if not self.available:
             return
+
+        self._logger.debug(
+            "YouTube focus signal: %s",
+            "active" if active else "inactive",
+        )
 
         if active:
             self._poll()
@@ -372,7 +468,7 @@ class MediaActivityMonitor:
             return
         self.youtube_playing = False
         self._last_playing_at = None
-        self._logger.debug("Watchable video playback inactive: %s", reason)
+        self._logger.debug("Watchable media playback inactive: %s", reason)
         self._on_youtube_stopped()
 
     def _poll(self) -> bool:
@@ -387,7 +483,7 @@ class MediaActivityMonitor:
             self._last_playing_at = now
             if not self.youtube_playing:
                 self.youtube_playing = True
-                self._logger.debug("Watchable video playback active")
+                self._logger.debug("Watchable media playback active")
                 self._on_youtube_started()
             return keep_running
 

--- a/src/mochi/presence/click_dialogue.py
+++ b/src/mochi/presence/click_dialogue.py
@@ -9,6 +9,7 @@ from gi.repository import GLib
 from mochi.sound import SoundEvent
 
 from .clicks import ClickBurstDetector
+from .edge_roam_controls import EdgeRoamMixin
 from .engine import SpeechText, speech_display_seconds
 from .integration import (
     PresenceBuddy as BasePresenceBuddy,
@@ -160,9 +161,19 @@ class ClickDialogueMixin:
             )
 
 
-class PresenceBuddy(ClickDialogueMixin, MusicDanceMixin, BasePresenceBuddy):
-    """Layer-shell buddy with Mochi Sense, music dance, and click dialogue."""
+class PresenceBuddy(
+    ClickDialogueMixin,
+    MusicDanceMixin,
+    EdgeRoamMixin,
+    BasePresenceBuddy,
+):
+    """Layer-shell buddy with Mochi Sense, music dance, edge roam, and dialogue."""
 
 
-class PresenceX11Buddy(ClickDialogueMixin, MusicDanceMixin, BasePresenceX11Buddy):
-    """X11/XWayland buddy with Mochi Sense, music dance, and click dialogue."""
+class PresenceX11Buddy(
+    ClickDialogueMixin,
+    MusicDanceMixin,
+    EdgeRoamMixin,
+    BasePresenceX11Buddy,
+):
+    """X11 buddy with Mochi Sense, music dance, edge roam, and dialogue."""

--- a/src/mochi/presence/edge_roam_controls.py
+++ b/src/mochi/presence/edge_roam_controls.py
@@ -1,0 +1,138 @@
+"""User-facing movement controls layered onto Mochi's existing presence stack."""
+
+from __future__ import annotations
+
+import random
+
+from gi.repository import Gtk
+
+from mochi.behavior import choose_walk_animation
+from mochi.edge_roam import build_edge_roam_motion
+from mochi.sprites import ANIMATIONS
+from mochi.state import MochiState
+
+
+class EdgeRoamMixin:
+    """Keep autonomous wandering on the current monitor's safe perimeter."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        self._edge_roam = False
+        self._edge_roam_switch: Gtk.Switch | None = None
+        self._edge_roam_clockwise = random.choice((True, False))
+        super().__init__(*args, **kwargs)
+
+    def _build_context_menu(self):
+        popover = super()._build_context_menu()
+        self._edge_roam = self._config.load_edge_roam()
+
+        edge_row, self._edge_roam_switch = self._make_edge_roam_row()
+        card = self._context_menu_content
+        # PresenceBuddyMixin already places Stay put immediately after Sleep.
+        # Insert Edge roam first so the movement controls read naturally:
+        # Sleep -> Edge roam -> Stay put -> Close.
+        card.insert_child_after(edge_row, self._sleep_button)
+
+        existing_rows = list(self._context_menu_animated_rows)
+        if existing_rows:
+            self._context_menu_animated_rows = (
+                existing_rows[0],
+                edge_row,
+                *existing_rows[1:],
+            )
+        else:
+            self._context_menu_animated_rows = (edge_row,)
+
+        popover._preferred_height = max(popover._preferred_height, 268)
+        popover.window.set_default_size(popover._preferred_width, popover._preferred_height)
+        return popover
+
+    def _make_edge_roam_row(self) -> tuple[Gtk.Button, Gtk.Switch]:
+        button = Gtk.Button()
+        button.add_css_class("mochi-menu-row")
+        button.set_tooltip_text("Keep Mochi's autonomous wandering along the screen edge")
+
+        row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
+        icon = Gtk.Image.new_from_icon_name("view-fullscreen-symbolic")
+        icon.add_css_class("mochi-menu-icon")
+        row.append(icon)
+
+        text = Gtk.Label(label="Edge roam")
+        text.set_xalign(0)
+        text.set_hexpand(True)
+        row.append(text)
+
+        switch = Gtk.Switch()
+        switch.set_valign(Gtk.Align.CENTER)
+        switch.set_active(self._edge_roam)
+        # Keep the whole row as one reliable target, matching Stay put.
+        switch.set_can_target(False)
+        switch.set_focusable(False)
+        row.append(switch)
+
+        button.set_child(row)
+        button.connect("clicked", self._toggle_edge_roam)
+        return button, switch
+
+    def _toggle_edge_roam(self, _button: Gtk.Button) -> None:
+        self._edge_roam = not self._edge_roam
+        self._config.save_edge_roam(self._edge_roam)
+        if self._edge_roam_switch is not None:
+            self._edge_roam_switch.set_active(self._edge_roam)
+
+        if self._edge_roam:
+            # Choose one direction per activation so Mochi feels like he is
+            # patrolling the perimeter instead of jittering back and forth.
+            self._edge_roam_clockwise = random.choice((True, False))
+            if self.state.current is MochiState.WALKING:
+                self._cancel_walk()
+                if self._transition_to(MochiState.IDLE):
+                    self._play_animation("idle")
+
+        self._logger.info(
+            "Edge roam %s%s",
+            "enabled" if self._edge_roam else "disabled",
+            " (Stay put currently overrides wandering)"
+            if self._edge_roam and getattr(self, "_stay_put", False)
+            else "",
+        )
+
+    def _start_walk(self) -> None:
+        # Autonomous walk timers can already be queued when a menu opens. Guard
+        # at the final movement entry point too so Mochi stays still while the
+        # user is interacting with either the context menu or Mochi Lab.
+        if self._context_menu_open:
+            self._logger.debug("Edge roam walk suppressed: menu open")
+            return
+
+        if not self._edge_roam:
+            super()._start_walk()
+            return
+
+        origin = self._placement.sync_from_window()
+        cycle_duration_ms = (
+            len(ANIMATIONS["walk"].frames)
+            * ANIMATIONS["walk"].frame_duration_ms
+        )
+        motion = build_edge_roam_motion(
+            self._placement,
+            origin,
+            travel_distance=random.randint(80, 240),
+            clockwise=self._edge_roam_clockwise,
+            cycle_duration_ms=cycle_duration_ms,
+            speed_px_per_second=self.WALK_SPEED_PX_PER_SECOND,
+        )
+        if motion is None or motion.distance <= 1.0:
+            return
+
+        self._walk_motion = motion
+        self._walk_elapsed_ms = 0
+        if not self._transition_to(MochiState.WALKING):
+            self._walk_motion = None
+            return
+        self._play_animation(choose_walk_animation(motion.origin, motion.target))
+        self._logger.debug(
+            "Edge roam walk origin=%s target=%s perimeter=%s",
+            motion.origin,
+            motion.target,
+            type(motion).__name__,
+        )

--- a/src/mochi/presence/music_dance.py
+++ b/src/mochi/presence/music_dance.py
@@ -66,8 +66,28 @@ class MusicDanceMixin:
             return
         super()._on_user_idle()
 
+    def _generic_browser_watch_active(self) -> bool:
+        """Return whether WATCHING came only from coarse focused-browser fallback."""
+        monitor = self._media_monitor
+        backend = getattr(monitor, "_backend", None) if monitor is not None else None
+        return bool(
+            monitor is not None
+            and monitor.youtube_playing
+            and getattr(backend, "watching_via_browser_focus", False)
+        )
+
     def _on_music_started(self) -> None:
         """Start the low-priority dance when recognized music begins."""
+        # Sparse Chromium MPRIS data can temporarily look like generic focused
+        # browser media. Confident music detection is more specific, so music
+        # may replace only that coarse fallback WATCHING state. Explicit
+        # YouTube/video detection continues to outrank dancing.
+        if (
+            self.state.current is MochiState.WATCHING
+            and self._generic_browser_watch_active()
+        ):
+            self._transition_to(MochiState.IDLE)
+            self._play_animation("idle")
         self._start_dancing_emote()
 
     def _on_music_stopped(self) -> None:
@@ -123,6 +143,17 @@ class MusicDanceMixin:
             return False
         return self._start_dancing_emote()
 
+    def _maybe_resume_watching(self) -> bool:
+        # A confidently detected music source outranks only the intentionally
+        # broad browser-focus fallback. Real/identified video still wins.
+        if (
+            self._music_monitor is not None
+            and self._music_monitor.music_playing
+            and self._generic_browser_watch_active()
+        ):
+            return False
+        return super()._maybe_resume_watching()
+
     def _maybe_resume_ambient_activity(self) -> bool:
         # Preserve Buddy's established media/file priority and insert music in
         # the middle. This is called after direct reactions and typing finish.
@@ -133,8 +164,15 @@ class MusicDanceMixin:
         )
 
     def _start_watching_emote(self) -> bool:
-        # Watchable video wins if it begins while music is already playing.
+        # Explicit watchable video wins over music. A coarse focused-browser
+        # fallback does not steal the state back from known music playback.
         if self.state.current is MochiState.DANCING:
+            if (
+                self._music_monitor is not None
+                and self._music_monitor.music_playing
+                and self._generic_browser_watch_active()
+            ):
+                return False
             self._transition_to(MochiState.IDLE)
             self._play_animation("idle")
         return super()._start_watching_emote()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -56,6 +56,15 @@ class ConfigStoreTests(unittest.TestCase):
             store.save_stay_put(False)
             self.assertFalse(store.load_stay_put())
 
+    def test_edge_roam_defaults_off_and_round_trips(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            store = ConfigStore(Path(directory) / "config.json")
+            self.assertFalse(store.load_edge_roam())
+            store.save_edge_roam(True)
+            self.assertTrue(store.load_edge_roam())
+            store.save_edge_roam(False)
+            self.assertFalse(store.load_edge_roam())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_edge_roam.py
+++ b/tests/test_edge_roam.py
@@ -1,0 +1,116 @@
+import unittest
+from types import SimpleNamespace
+
+from mochi.config import Position
+from mochi.edge_roam import (
+    EdgeBounds,
+    EdgeWalkMotion,
+    build_edge_roam_motion,
+    nearest_edge_point,
+)
+
+
+class _Placement:
+    EDGE_PADDING_PX = 8
+    BOTTOM_PADDING_PX = 12
+
+    def __init__(self, *, width=100, height=100, scale=1.0) -> None:
+        geometry = SimpleNamespace(x=0, y=0, width=1000, height=800)
+        monitor = SimpleNamespace(get_geometry=lambda: geometry)
+        self.window = SimpleNamespace(get_default_size=lambda: (width, height))
+        self.layer_shell_enabled = False
+        self._scale = scale
+        self._monitor = monitor
+
+    def _monitor_for_position(self, _x, _y):
+        return self._monitor
+
+    def _x11_coordinate_scale(self):
+        return self._scale
+
+
+class EdgeRoamTests(unittest.TestCase):
+    def test_center_position_projects_to_nearest_edge(self) -> None:
+        bounds = EdgeBounds(8, 892, 8, 688)
+        point = nearest_edge_point(Position(450, 300), bounds)
+        self.assertEqual(point, Position(450, 8))
+
+    def test_first_edge_roam_walk_heads_to_nearest_edge(self) -> None:
+        motion = build_edge_roam_motion(
+            _Placement(),
+            Position(450, 300),
+            travel_distance=160,
+            clockwise=True,
+            cycle_duration_ms=800,
+            speed_px_per_second=72,
+        )
+        self.assertIsNotNone(motion)
+        self.assertNotIsInstance(motion, EdgeWalkMotion)
+        self.assertEqual(motion.target, (450, 8))
+
+    def test_perimeter_motion_rounds_corner_without_crossing_interior(self) -> None:
+        motion = build_edge_roam_motion(
+            _Placement(),
+            Position(850, 8),
+            travel_distance=160,
+            clockwise=True,
+            cycle_duration_ms=800,
+            speed_px_per_second=72,
+        )
+        self.assertIsInstance(motion, EdgeWalkMotion)
+        samples = [
+            motion.position_at(round(motion.duration_ms * fraction / 10))
+            for fraction in range(11)
+        ]
+        for x, y in samples:
+            self.assertTrue(
+                x in (motion.bounds.left, motion.bounds.right)
+                or y in (motion.bounds.top, motion.bounds.bottom),
+                f"edge roam entered the interior at {(x, y)}",
+            )
+
+    def test_counterclockwise_motion_stays_on_perimeter(self) -> None:
+        motion = build_edge_roam_motion(
+            _Placement(),
+            Position(300, 688),
+            travel_distance=220,
+            clockwise=False,
+            cycle_duration_ms=800,
+            speed_px_per_second=72,
+        )
+        self.assertIsInstance(motion, EdgeWalkMotion)
+        for elapsed in range(0, motion.duration_ms + 1, max(1, motion.duration_ms // 12)):
+            x, y = motion.position_at(elapsed)
+            self.assertTrue(
+                x in (motion.bounds.left, motion.bounds.right)
+                or y in (motion.bounds.top, motion.bounds.bottom)
+            )
+
+    def test_scaled_xwayland_approach_uses_device_pixel_edge(self) -> None:
+        motion = build_edge_roam_motion(
+            _Placement(scale=2.0),
+            Position(900, 500),
+            travel_distance=120,
+            clockwise=True,
+            cycle_duration_ms=800,
+            speed_px_per_second=72,
+        )
+        self.assertIsNotNone(motion)
+        self.assertNotIsInstance(motion, EdgeWalkMotion)
+        self.assertEqual(motion.target, (900, 16))
+
+    def test_scaled_xwayland_perimeter_uses_device_pixel_bounds(self) -> None:
+        motion = build_edge_roam_motion(
+            _Placement(scale=2.0),
+            Position(900, 16),
+            travel_distance=120,
+            clockwise=True,
+            cycle_duration_ms=800,
+            speed_px_per_second=72,
+        )
+        self.assertIsInstance(motion, EdgeWalkMotion)
+        self.assertEqual(motion.bounds, EdgeBounds(16, 1784, 16, 1376))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_media_focus_fallback.py
+++ b/tests/test_media_focus_fallback.py
@@ -1,0 +1,95 @@
+import unittest
+from unittest.mock import Mock
+
+from mochi.media_activity import MediaActivityMonitor, MprisMediaBackend
+
+
+class _Parameters:
+    def __init__(self, category: str) -> None:
+        self._category = category
+
+    def unpack(self):
+        return (self._category,)
+
+
+class MediaFocusFallbackTests(unittest.TestCase):
+    def test_sparse_chromium_mpris_is_media_when_browser_is_focused(self) -> None:
+        backend = MprisMediaBackend()
+        backend.set_focused_browser(True)
+        properties = {
+            "PlaybackStatus": "Playing",
+            "Metadata": {
+                "xesam:title": "I Play Fallout New Vegas, You Relax/Sleep",
+                "xesam:url": "",
+            },
+        }
+        backend._get_property = (
+            lambda _bus_name, property_name, _gio, _glib: properties[property_name]
+        )
+
+        self.assertTrue(
+            backend._player_is_youtube_playing(
+                "org.mpris.MediaPlayer2.chromium.instance387598",
+                object(),
+                object(),
+            )
+        )
+        self.assertTrue(backend.watching_via_browser_focus)
+
+    def test_sparse_chromium_mpris_is_ignored_when_browser_is_not_focused(self) -> None:
+        backend = MprisMediaBackend()
+        properties = {
+            "PlaybackStatus": "Playing",
+            "Metadata": {"xesam:title": "A song", "xesam:url": ""},
+        }
+        backend._get_property = (
+            lambda _bus_name, property_name, _gio, _glib: properties[property_name]
+        )
+
+        self.assertFalse(
+            backend._player_is_youtube_playing(
+                "org.mpris.MediaPlayer2.chromium.instance387598",
+                object(),
+                object(),
+            )
+        )
+
+    def test_coarse_app_category_updates_browser_focus_only(self) -> None:
+        backend = MprisMediaBackend()
+        changed = Mock()
+        backend.set_browser_focus_changed_callback(changed)
+
+        backend._on_app_category_changed(
+            None, None, None, None, None, _Parameters("browser")
+        )
+        self.assertTrue(backend._focused_browser)
+        changed.assert_called_once_with(True)
+
+        backend._on_app_category_changed(
+            None, None, None, None, None, _Parameters("editor")
+        )
+        self.assertFalse(backend._focused_browser)
+        self.assertEqual(changed.call_args_list[-1].args, (False,))
+
+    def test_browser_focus_loss_stops_focus_dependent_media_immediately(self) -> None:
+        stopped = Mock()
+        backend = Mock()
+        backend.watching_via_browser_focus = True
+        monitor = MediaActivityMonitor(
+            on_youtube_started=Mock(),
+            on_youtube_stopped=stopped,
+            backend=backend,
+        )
+        monitor.available = True
+        monitor.youtube_playing = True
+        monitor._last_playing_at = 10.0
+
+        monitor._on_browser_focus_changed(False)
+
+        self.assertFalse(monitor.youtube_playing)
+        self.assertIsNone(monitor._last_playing_at)
+        stopped.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Cleans and preserves the useful work from the old `feat/media-edge-roam` line on top of current `main` without carrying over duplicate dance code or temporary files.

### Changes
- adds Edge Roam perimeter-only autonomous walking
- persists the Edge Roam preference
- layers Edge Roam into the current click-dialogue + music-dance presence stack
- adds edge-roam geometry/config tests
- preserves the Chromium sparse-MPRIS focused-browser fallback
- expands browser/title handling in the GNOME Shell helper
- keeps confidently detected music above only the generic browser fallback, while explicit video still wins

### Cleanup
- no duplicate dance assets
- no placeholder/temp files from the old branch
- no replacement of the working `music_activity.py` implementation
- branch is built directly from current `main`
