### PR TITLE
site: promote public alpha landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <meta name="theme-color" content="#fbfbfe" />
   <meta
     name="description"
-    content="Mochi is a tiny handcrafted desktop companion for Linux. First public alpha September 21, 2026."
+    content="Mochi is a tiny handcrafted Linux desktop companion with privacy-first ambient awareness. Early public alpha available now for Fedora GNOME."
   />
   <title>Mochi — Tiny desktop companion</title>
   <link rel="stylesheet" href="styles.css" />
@@ -23,23 +23,23 @@
 
     <nav aria-label="Main navigation">
       <a href="#about">About</a>
-      <a href="#release">Release</a>
+      <a href="#install">Install</a>
       <a href="https://github.com/miflow13/mochi-desktop" target="_blank" rel="noreferrer">GitHub</a>
     </nav>
   </header>
 
   <main id="top">
     <section class="hero">
-      <p class="eyebrow">A tiny desktop companion for Linux</p>
+      <p class="eyebrow">Early public alpha · Fedora + GNOME</p>
       <h1>Soft, playful, and quietly alive.</h1>
       <p class="hero-copy">
-        Meet Mochi — a handcrafted pixel desktop friend designed to bring a little
-        warmth, personality, and charm to your screen.
+        Meet Mochi — a handcrafted pixel companion who wanders, reacts, chats,
+        sleeps, and notices the shape of activity around your Linux desktop.
       </p>
 
       <div class="hero-actions">
-        <a class="button button-primary" href="https://github.com/miflow13/mochi-desktop" target="_blank" rel="noreferrer">Star Mochi on GitHub</a>
-        <a class="button button-secondary" href="#release">Alpha · September 21</a>
+        <a class="button button-primary" href="#install">Install Mochi</a>
+        <a class="button button-secondary" href="https://github.com/miflow13/mochi-desktop" target="_blank" rel="noreferrer">View on GitHub</a>
       </div>
 
       <div class="hero-visual">
@@ -52,37 +52,38 @@
     <section class="overview" id="about">
       <div class="section-intro">
         <p class="eyebrow">Designed with care</p>
-        <h2>Small enough to live on your desktop.</h2>
+        <h2>A little creature, not another dashboard.</h2>
         <p>
-          Mochi is a tiny companion with handcrafted pixel art, expressive animation,
-          and a lightweight Linux-native feel.
+          Mochi is made to feel at home on your desktop: expressive enough to have
+          personality, lightweight enough to leave running, and easy to ignore when
+          you're busy.
         </p>
       </div>
 
       <div class="feature-grid">
         <article class="feature-card">
           <h3>Handcrafted</h3>
-          <p>Original sprites and animations made frame by frame with love.</p>
+          <p>Original pixel-art sprites and animations made frame by frame with love.</p>
         </article>
         <article class="feature-card">
-          <h3>Expressive</h3>
-          <p>Clicks, movement, and little emotes give Mochi real personality.</p>
+          <h3>Mochi Sense</h3>
+          <p>Privacy-first local awareness lets Mochi react to broad activity without reading what you type.</p>
         </article>
         <article class="feature-card">
-          <h3>Minimal</h3>
-          <p>Made to feel at home on your screen without becoming visually noisy.</p>
+          <h3>Linux-native spirit</h3>
+          <p>Built around GTK4, GNOME, Wayland/XWayland, and the tiny details of a real Linux desktop.</p>
         </article>
       </div>
     </section>
 
-    <section class="download" id="release">
+    <section class="download" id="install">
       <div class="download-copy">
-        <p class="eyebrow">First public alpha</p>
-        <h2>September 21, 2026.</h2>
+        <p class="eyebrow">Early public alpha</p>
+        <h2>Bring Mochi home.</h2>
         <p>
-          Mochi is still growing. The first public alpha is planned for September 21,
-          with early testing focused on Linux desktop compatibility, interactions,
-          animation behavior, and reliability.
+          Fedora + GNOME on Wayland is the actively tested environment. The installer
+          handles Fedora dependencies, Mochi's private Python environment, the GNOME
+          helper, and an app-grid launcher.
         </p>
       </div>
 
@@ -90,36 +91,36 @@
         <div class="step">
           <span class="step-number">01</span>
           <div>
-            <h3>Star the project</h3>
-            <p>Star Mochi on GitHub if you'd like to support the project and follow its progress.</p>
+            <h3>Clone Mochi</h3>
+            <p><code>git clone https://github.com/miflow13/mochi-desktop.git</code></p>
           </div>
         </div>
 
         <div class="step">
           <span class="step-number">02</span>
           <div>
-            <h3>Watch development</h3>
-            <p>Watch the repository for project updates as Mochi gets closer to the first alpha.</p>
+            <h3>Run the installer</h3>
+            <p><code>cd mochi-desktop &amp;&amp; ./install.sh</code></p>
           </div>
         </div>
 
         <div class="step">
           <span class="step-number">03</span>
           <div>
-            <h3>Help shape Mochi</h3>
-            <p>Feature ideas, Linux compatibility feedback, and alpha testing interest are welcome.</p>
+            <h3>Open Mochi</h3>
+            <p>Launch <strong>Mochi</strong> from the GNOME app grid. Right-click him and choose <strong>Quit Mochi</strong> whenever you want him to go away.</p>
           </div>
         </div>
 
         <div class="download-actions">
-          <a class="button button-primary" href="https://github.com/miflow13/mochi-desktop" target="_blank" rel="noreferrer">Star on GitHub</a>
-          <a class="text-link" href="https://github.com/miflow13/mochi-desktop/issues" target="_blank" rel="noreferrer">Share feedback & ideas</a>
+          <a class="button button-primary" href="https://github.com/miflow13/mochi-desktop#install-mochi" target="_blank" rel="noreferrer">Installation guide</a>
+          <a class="text-link" href="https://github.com/miflow13/mochi-desktop/issues" target="_blank" rel="noreferrer">Report an alpha bug</a>
         </div>
       </div>
     </section>
 
     <section class="closing">
-      <p>Mochi brings a little life to your desktop.</p>
+      <p>A few pixels. A little personality. 🌱</p>
     </section>
   </main>
 

--- a/styles.css
+++ b/styles.css
@@ -329,6 +329,8 @@ code {
   background: rgba(114, 229, 97, 0.14);
   border: 1px solid rgba(17, 17, 20, 0.06);
   font-size: 0.88em;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .closing {


### PR DESCRIPTION
Promotes the two staged public-alpha website commits to the live GitHub Pages branch.

Changes:
- publish the updated public alpha landing page
- keep install commands readable on mobile

This PR targets `gh-pages` only and does not modify `main`.