### PR TITLE
fix: keep YouTube video above dance priority

### DIFF
--- a/src/mochi/music_activity.py
+++ b/src/mochi/music_activity.py
@@ -56,6 +56,19 @@ _MUSIC_PLAYER_MARKERS = (
     "mpd",
 )
 
+# Browser playback needs a source-specific signal before it is called music.
+# Artist/album metadata alone is not enough because normal YouTube videos often
+# expose channel/creator fields through MPRIS that look music-like.
+_MUSIC_WEB_HOSTS = (
+    "open.spotify.com",
+    "soundcloud.com",
+    "bandcamp.com",
+    "music.apple.com",
+    "tidal.com",
+    "deezer.com",
+    "pandora.com",
+)
+
 
 class MprisMusicBackend:
     """Reduce MPRIS state to a conservative music-playing boolean."""
@@ -163,14 +176,18 @@ class MprisMusicBackend:
             return False
 
         metadata = self._get_property(bus_name, "Metadata", Gio, GLib)
+        is_browser = _is_browser_player(bus_name)
         if _metadata_indicates_watchable_video(metadata):
             return False
-        if _metadata_indicates_music(metadata):
+        if _metadata_indicates_music(
+            metadata,
+            allow_artist_album=not is_browser,
+        ):
             return True
 
         # A browser with ambiguous metadata could be playing any kind of media,
-        # so never classify it as music from playback state alone.
-        if _is_browser_player(bus_name):
+        # so never classify it as music from playback or artist/album state alone.
+        if is_browser:
             return False
         return _is_music_first_player(bus_name)
 
@@ -322,7 +339,19 @@ def _url_is_youtube_music(value: str) -> bool:
     return host == "music.youtube.com" or host.endswith(".music.youtube.com")
 
 
-def _metadata_indicates_music(metadata) -> bool:
+def _url_is_known_music_service(value: str) -> bool:
+    try:
+        host = (urlparse(value).hostname or "").lower().rstrip(".")
+    except Exception:
+        return False
+    return any(host == domain or host.endswith(f".{domain}") for domain in _MUSIC_WEB_HOSTS)
+
+
+def _metadata_indicates_music(
+    metadata,
+    *,
+    allow_artist_album: bool = True,
+) -> bool:
     """Conservatively classify transient MPRIS metadata as music."""
     metadata = _deep_unpack(metadata)
     if not isinstance(metadata, dict):
@@ -331,7 +360,11 @@ def _metadata_indicates_music(metadata) -> bool:
         return False
 
     for value in _string_values(metadata.get("xesam:url")):
-        if _url_is_youtube_music(value) or _looks_like_audio_file(value):
+        if (
+            _url_is_youtube_music(value)
+            or _url_is_known_music_service(value)
+            or _looks_like_audio_file(value)
+        ):
             return True
 
     for value in _string_values(metadata.get("xesam:title")):
@@ -339,12 +372,20 @@ def _metadata_indicates_music(metadata) -> bool:
         if "youtube music" in lowered or _looks_like_audio_file(value):
             return True
 
-    # xesam:artist/album are strong media-type signals and are supplied by
-    # Spotify and most Linux music players without needing to identify a track.
-    if any(value.strip() for value in _string_values(metadata.get("xesam:artist"))):
-        return True
-    if any(value.strip() for value in _string_values(metadata.get("xesam:album"))):
-        return True
+    # Native music players commonly expose artist/album without a useful URL.
+    # Browser video can expose creator/channel fields in the same MPRIS keys,
+    # so browser callers intentionally disable this fallback.
+    if allow_artist_album:
+        if any(
+            value.strip()
+            for value in _string_values(metadata.get("xesam:artist"))
+        ):
+            return True
+        if any(
+            value.strip()
+            for value in _string_values(metadata.get("xesam:album"))
+        ):
+            return True
 
     return False
 

--- a/tests/test_music_activity.py
+++ b/tests/test_music_activity.py
@@ -89,6 +89,32 @@ class MprisMusicBackendTests(unittest.TestCase):
             "xesam:title": "A video - YouTube",
         }))
 
+    def test_browser_creator_metadata_alone_is_not_music(self):
+        backend = self._backend({
+            "org.mpris.MediaPlayer2.chromium.instance123": {
+                "PlaybackStatus": "Playing",
+                "Metadata": {
+                    "xesam:title": "A normal YouTube video",
+                    "xesam:artist": ["Video channel"],
+                    "xesam:url": "",
+                },
+            }
+        })
+        self.assertFalse(backend.sample_music_playing())
+
+    def test_spotify_web_url_is_music(self):
+        backend = self._backend({
+            "org.mpris.MediaPlayer2.chromium.instance123": {
+                "PlaybackStatus": "Playing",
+                "Metadata": {
+                    "xesam:title": "A track",
+                    "xesam:artist": ["An artist"],
+                    "xesam:url": "https://open.spotify.com/track/abc",
+                },
+            }
+        })
+        self.assertTrue(backend.sample_music_playing())
+
     def test_local_audio_file_is_music(self):
         self.assertTrue(_metadata_indicates_music({
             "xesam:url": "file:///home/user/Music/song.flac"


### PR DESCRIPTION
Fixes the alpha QA regression where a YouTube video could be misclassified as music and switch Mochi from WATCHING to DANCING.

Changes:
- browser artist/album metadata alone no longer qualifies as music
- known browser music services (Spotify Web, SoundCloud, Bandcamp, Apple Music, TIDAL, Deezer, Pandora) remain eligible by URL
- YouTube Music remains supported
- adds regression coverage for browser creator metadata and Spotify Web

This preserves the intended priority: explicit watchable video > music > file browsing > idle.