### PR TITLE
fix: stop clean-VM typing feedback loop

### DIFF
--- a/src/mochi/app.py
+++ b/src/mochi/app.py
@@ -197,6 +197,27 @@ class MochiApplication(Gtk.Application):
                 background-color: alpha(@theme_fg_color, 0.09);
                 min-height: 1px;
             }
+
+            /* Speech bubbles live on transparent toplevels, so the capsule
+             * must paint its own theme-safe surface and foreground. */
+            .mochi-speech-bubble {
+                background-color: @theme_bg_color;
+                color: @theme_fg_color;
+                border-color: alpha(#79c98b, 0.42);
+            }
+
+            .mochi-speech-text {
+                color: @theme_fg_color;
+            }
+
+            .mochi-speech-text.mochi-speech-typing {
+                color: alpha(@theme_fg_color, 0.78);
+            }
+
+            popover.mochi-speech-popover > arrow {
+                background-color: @theme_bg_color;
+                border-color: alpha(#79c98b, 0.42);
+            }
             """
         )
         Gtk.StyleContext.add_provider_for_display(

--- a/src/mochi/typing_activity.py
+++ b/src/mochi/typing_activity.py
@@ -325,19 +325,20 @@ class AtspiTextActivityBackend:
     """Safe AT-SPI text/caret activity backend.
 
     Coverage depends on applications exposing accessibility events. Event
-    contents and accessible source objects are never inspected. This is the
-    default Wayland-safe runtime backend because compositor-wide keyboard
-    monitoring is privileged for screen-reader use on GNOME.
+    contents and accessible source objects are never inspected. Runtime use can
+    disable broad text-changed events and listen only for caret movement so
+    Mochi's own changing labels cannot feed activity back into the detector.
     """
 
     name = "AT-SPI text/caret activity"
     TEXT_CHANGED_EVENT = "object:text-changed"
     CARET_MOVED_EVENT = "object:text-caret-moved"
 
-    def __init__(self) -> None:
+    def __init__(self, *, allow_text_changed: bool = True) -> None:
         self._listener = None
         self._registered_events: list[str] = []
         self._on_activity: Callable[[], None] | None = None
+        self._allow_text_changed = bool(allow_text_changed)
         self.last_error: str | None = None
 
     @property
@@ -360,7 +361,10 @@ class AtspiTextActivityBackend:
             self._listener = listener
             self._on_activity = on_activity
 
-            for event_name in (self.TEXT_CHANGED_EVENT, self.CARET_MOVED_EVENT):
+            event_names = [self.CARET_MOVED_EVENT]
+            if self._allow_text_changed:
+                event_names.insert(0, self.TEXT_CHANGED_EVENT)
+            for event_name in event_names:
                 if listener.register(event_name):
                     self._registered_events.append(event_name)
 
@@ -391,10 +395,11 @@ class AtspiTextActivityBackend:
         # Inspect only the event category. Never inspect source, inserted text,
         # key values, or any other accessibility payload.
         event_type = getattr(event, "type", "") or ""
-        if not (
-            event_type.startswith(self.TEXT_CHANGED_EVENT)
-            or event_type.startswith(self.CARET_MOVED_EVENT)
-        ):
+        caret_event = event_type.startswith(self.CARET_MOVED_EVENT)
+        text_event = self._allow_text_changed and event_type.startswith(
+            self.TEXT_CHANGED_EVENT
+        )
+        if not (caret_event or text_event):
             return
 
         callback = self._on_activity
@@ -428,11 +433,13 @@ class TypingActivityMonitor:
         self._detector = detector or TypingBurstDetector()
         # Prefer the tiny GNOME Shell companion extension for broad activity.
         # It sends a zero-argument D-Bus Pulse and never transports key data.
-        # AT-SPI text/caret activity remains a limited fallback when the
-        # extension is not installed or enabled.
+        # AT-SPI caret activity remains a limited fallback when the extension is
+        # not installed or enabled. Broad text-changed events are disabled in
+        # the runtime fallback because Mochi's own animated speech labels can
+        # otherwise generate a self-sustaining feedback loop.
         self._backends = tuple(backends) if backends is not None else (
             GnomeShellTypingPulseBackend(),
-            AtspiTextActivityBackend(),
+            AtspiTextActivityBackend(allow_text_changed=False),
         )
         self._logger = logger or logging.getLogger(__name__)
 

--- a/tests/test_typing_feedback_guard.py
+++ b/tests/test_typing_feedback_guard.py
@@ -1,0 +1,35 @@
+import unittest
+
+from mochi.typing_activity import AtspiTextActivityBackend, TypingActivityMonitor
+
+
+class _Event:
+    def __init__(self, event_type: str) -> None:
+        self.type = event_type
+
+
+class TypingFeedbackGuardTests(unittest.TestCase):
+    def test_runtime_fallback_ignores_text_changed_but_keeps_caret_activity(self) -> None:
+        monitor = TypingActivityMonitor(
+            on_typing_activity=lambda: None,
+            on_typing_stopped=lambda: None,
+        )
+        backend = monitor._backends[1]
+        self.assertIsInstance(backend, AtspiTextActivityBackend)
+
+        calls = 0
+
+        def activity() -> None:
+            nonlocal calls
+            calls += 1
+
+        backend._on_activity = activity
+        backend._on_accessibility_event(_Event("object:text-changed:insert"))
+        self.assertEqual(calls, 0)
+
+        backend._on_accessibility_event(_Event("object:text-caret-moved"))
+        self.assertEqual(calls, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes the clean Fedora VM alpha QA issue where Mochi's AT-SPI fallback could treat its own animated speech-label text changes as continuous typing.

Changes:
- runtime AT-SPI fallback now listens to caret movement without broad text-changed events
- preserves the existing GNOME Shell pulse backend as the preferred path
- keeps the standalone text backend compatible for targeted tests/tools
- adds a regression test proving runtime text-changed events are ignored while caret activity still works
- improves speech-bubble contrast using portable GTK theme colors for light/dark mode

Please verify in the clean Fedora VM before merge: launch Mochi and leave it idle for ~30 seconds without typing. The terminal should not spam typing intensity or enter a sustained TYPING state by itself. Then type normally in the terminal/editor and confirm typing detection still occurs when the fallback exposes caret events.