### PR TITLE
refactor: rename Mochi Sense to AmbiSense

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [website](https://miflow13.github.io/mochi-desktop/) · [issues](https://github.com/miflow13/mochi-desktop/issues) · [animation guide](assets/mochi/README.md)
 
-Mochi is a lightweight Linux desktop companion designed to make the desktop feel a little more alive. He wanders, reacts to clicks and dragging, notices broad desktop activity through **Mochi Sense**, sleeps, chats, and mostly keeps to himself.
+Mochi is a lightweight Linux desktop companion designed to make the desktop feel a little more alive. He wanders, reacts to clicks and dragging, notices broad desktop activity through **AmbiSense**, sleeps, chats, and mostly keeps to himself.
 
 Mochi is currently an **early public alpha**. Fedora + GNOME on Wayland is the actively tested environment; XWayland is used where GNOME's native Wayland restrictions require it.
 
@@ -84,7 +84,7 @@ Working now:
 - click chirps + triple-click dialogue
 - sleep / wake behavior
 - typing + media companion states
-- Mochi Sense ambient dialogue
+- AmbiSense ambient dialogue
 - multi-monitor / XWayland reliability work
 
 Still growing:
@@ -93,13 +93,13 @@ Still growing:
 - animation-library polish
 - broader Linux compatibility
 - installation testing outside the dev machines
-- more Mochi Sense contexts
+- more AmbiSense contexts
 
 ---
 
-## Mochi Sense
+## AmbiSense
 
-**Mochi Sense** is Mochi's lightweight local awareness system. It turns privacy-reduced desktop signals into small behavior decisions: say something, react, perform an activity, or simply do nothing.
+**AmbiSense** is Mochi's lightweight local awareness system. It turns privacy-reduced desktop signals into small behavior decisions: say something, react, perform an activity, or simply do nothing.
 
 Depending on what is available on the system, Mochi can notice broad signals such as:
 
@@ -111,7 +111,7 @@ Depending on what is available on the system, Mochi can notice broad signals suc
 - network connection transitions
 - file-browsing activity
 
-Mochi Sense is a **local rule-based behavior engine**, not an LLM and not a cloud AI service.
+AmbiSense is a **local rule-based behavior engine**, not an LLM and not a cloud AI service.
 
 ### privacy
 
@@ -129,7 +129,7 @@ Application awareness is reduced to broad semantic categories before Mochi react
 - **Drag** — pick Mochi up and move him around
 - **Right-click** — size, audio, sleep/wake, **Stay put**, and Quit
 - **Stay put** — disables autonomous wandering without freezing other behavior
-- **Mochi Lab** — developer controls for animations and Mochi Sense tuning
+- **Mochi Lab** — developer controls for animations and AmbiSense tuning
 
 Nothing requires a response. You can ignore Mochi completely and let him do his little thing.
 
@@ -160,7 +160,7 @@ See [`assets/mochi/README.md`](assets/mochi/README.md) for frame, naming, loopin
 Mochi is also a hands-on Linux software-engineering project. Current work includes:
 
 - state-driven behavior for idle, movement, reactions, sleep, media, typing, and interaction transitions
-- privacy-first event and context handling through Mochi Sense
+- privacy-first event and context handling through AmbiSense
 - manifest-driven sprite assets with runtime inventory validation
 - per-frame animation timing with cached Cairo surfaces and nearest-neighbor rendering
 - persistent configuration for placement and preferences
@@ -182,7 +182,7 @@ The actively tested target is **Fedora Linux + GNOME + Wayland**. Other distribu
 | version | focus |
 | --- | --- |
 | **v0.1 — Exists** | core desktop buddy functionality |
-| **v0.2 — Feels alive** | animation polish, Mochi Sense, reactions, contextual behavior, reliability, public alpha |
+| **v0.2 — Feels alive** | animation polish, AmbiSense, reactions, contextual behavior, reliability, public alpha |
 | **v0.3 — Needs care** | lightweight care / progression without turning Mochi into a chore |
 | **v0.4 — Develops personality** | more behaviors, expressions, traits, and cosmetic personality |
 | **v0.5 — Lives on your desktop** | deeper Linux desktop interactions and broader environment support |

--- a/docs/ambisense.md
+++ b/docs/ambisense.md
@@ -1,0 +1,7 @@
+# AmbiSense
+
+**AmbiSense** is the name of Mochi's lightweight local ambient-awareness system.
+
+It turns privacy-reduced desktop signals into small behavior decisions without reading the content of what the user types.
+
+The implementation continues to use `presence` internally (`PresenceEngine`, `PresenceBuddyMixin`, and related modules). Those names describe the code architecture; **AmbiSense** is the user-facing subsystem name.

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
       <ul>
         <li>Hand-drawn pixel art and animations.</li>
         <li>Reacts to typing, terminal use, coding, music, video, idle time, and more.</li>
-        <li>Mochi Sense uses broad desktop signals instead of reading what you type.</li>
+        <li>AmbiSense uses broad desktop signals instead of reading what you type.</li>
         <li>Built primarily for Fedora GNOME with Wayland/XWayland.</li>
         <li>Still alpha software. Bugs are part of the deal.</li>
       </ul>

--- a/src/mochi/presence/click_dialogue.py
+++ b/src/mochi/presence/click_dialogue.py
@@ -108,7 +108,7 @@ class ClickDialogueMixin:
         self._last_click_burst_phrase = text
 
         # This is a direct user interaction, not unsolicited ambient speech.
-        # Replace any current bubble and do not spend Mochi Sense cooldown budget.
+        # Replace any current bubble and do not spend AmbiSense cooldown budget.
         self._dismiss_presence_bubble(user_initiated=False)
         shown = bubble.show(
             text,
@@ -193,7 +193,7 @@ class PresenceBuddy(
     EdgeRoamMixin,
     BasePresenceBuddy,
 ):
-    """Layer-shell buddy with terminal coworking, Mochi Sense, music, and dialogue."""
+    """Layer-shell buddy with terminal coworking, AmbiSense, music, and dialogue."""
 
 
 class PresenceX11Buddy(
@@ -206,4 +206,4 @@ class PresenceX11Buddy(
     EdgeRoamMixin,
     BasePresenceX11Buddy,
 ):
-    """X11 buddy with terminal coworking, Mochi Sense, music, and dialogue."""
+    """X11 buddy with terminal coworking, AmbiSense, music, and dialogue."""

--- a/src/mochi/presence/engine.py
+++ b/src/mochi/presence/engine.py
@@ -1,4 +1,4 @@
-"""Decision engine for Mochi Sense ambient awareness."""
+"""Decision engine for AmbiSense ambient awareness."""
 
 from __future__ import annotations
 
@@ -72,7 +72,7 @@ class PresenceAction:
     display_seconds: float = 3.5
 
     def __post_init__(self) -> None:
-        # Normal ambient/contextual Mochi Sense speech gets the small fake
+        # Normal ambient/contextual AmbiSense speech gets the small fake
         # typing beat. Critical system reactions stay immediate. Startup,
         # direct click reactions, drag dialogue, and developer previews do not
         # use PresenceAction and therefore remain immediate automatically.

--- a/src/mochi/presence/integration.py
+++ b/src/mochi/presence/integration.py
@@ -1,4 +1,4 @@
-"""Thin integration layer between Buddy and Mochi Sense ambient awareness."""
+"""Thin integration layer between Buddy and AmbiSense ambient awareness."""
 
 from __future__ import annotations
 
@@ -19,7 +19,7 @@ from .signals import AppCategorySignalAdapter, SystemSignalMonitor
 
 
 class PresenceBuddyMixin:
-    """Add Mochi Sense without changing Buddy's proven interaction code."""
+    """Add AmbiSense without changing Buddy's proven interaction code."""
 
     PRESENCE_EVALUATION_SECONDS = 5
     STARTUP_GREETING_DELAY_MS = 1_100
@@ -27,7 +27,7 @@ class PresenceBuddyMixin:
 
     def __init__(self, *args, **kwargs) -> None:
         self._ambient_presence_engine = PresenceEngine()
-        # Mochi Sense is lively by default. Extra-chatty remains an optional
+        # AmbiSense is lively by default. Extra-chatty remains an optional
         # developer stress-test profile rather than defining normal behavior.
         self._presence_chatty_test_mode = False
         self._presence_chatty_switch: Gtk.Switch | None = None
@@ -85,7 +85,7 @@ class PresenceBuddyMixin:
 
     @property
     def presence_engine(self) -> PresenceEngine:
-        """Developer/test access to the Mochi Sense decision engine."""
+        """Developer/test access to the AmbiSense decision engine."""
         return self._ambient_presence_engine
 
     def _build_context_menu(self):
@@ -176,9 +176,9 @@ class PresenceBuddyMixin:
             self._schedule_idle_action()
 
     def _build_developer_menu(self):
-        """Extend Mochi Lab with isolated Mochi Sense controls.
+        """Extend Mochi Lab with isolated AmbiSense controls.
 
-        Buddy still owns the developer surface and lifecycle. Mochi Sense appends
+        Buddy still owns the developer surface and lifecycle. AmbiSense appends
         its widgets without changing the user menu lifecycle, then promotes the
         Lab surface into a conventional resizable, scrollable GTK window.
         """
@@ -188,7 +188,7 @@ class PresenceBuddyMixin:
 
         card.append(Gtk.Separator(orientation=Gtk.Orientation.HORIZONTAL))
 
-        presence_label = Gtk.Label(label="Mochi Sense")
+        presence_label = Gtk.Label(label="AmbiSense")
         presence_label.set_xalign(0)
         presence_label.add_css_class("mochi-menu-section")
         card.append(presence_label)
@@ -217,7 +217,7 @@ class PresenceBuddyMixin:
         card.append(quiet_row)
         animated_rows.append(quiet_row)
 
-        # Extra-chatty is intentionally button-backed. The normal Mochi Sense
+        # Extra-chatty is intentionally button-backed. The normal AmbiSense
         # profile is already lively; this control exists only for stress testing.
         chatty_row, self._presence_chatty_switch = self._make_presence_chatty_row()
         card.append(chatty_row)
@@ -295,7 +295,7 @@ class PresenceBuddyMixin:
         button = Gtk.Button()
         button.add_css_class("mochi-menu-row")
         button.set_tooltip_text(
-            "Stress-test Mochi Sense with much faster ambient speech"
+            "Stress-test AmbiSense with much faster ambient speech"
         )
 
         row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=10)
@@ -364,7 +364,7 @@ class PresenceBuddyMixin:
     def _apply_presence_chatty_test_mode(
         self, enabled: bool, *, clear_cooldowns: bool = True
     ) -> None:
-        """Swap between normal Mochi Sense and an aggressive stress-test profile."""
+        """Swap between normal AmbiSense and an aggressive stress-test profile."""
         self._presence_chatty_test_mode = bool(enabled)
         engine = self._ambient_presence_engine
         tuning = engine.tuning
@@ -415,7 +415,7 @@ class PresenceBuddyMixin:
         logger = getattr(self, "_logger", None)
         if logger is not None:
             logger.info(
-                "Mochi Sense extra-chatty mode %s",
+                "AmbiSense extra-chatty mode %s",
                 "enabled" if enabled else "disabled",
             )
 
@@ -755,8 +755,8 @@ class PresenceBuddyMixin:
 
 
 class PresenceBuddy(PresenceBuddyMixin, Buddy):
-    """Wayland/layer-shell Buddy with Mochi Sense."""
+    """Wayland/layer-shell Buddy with AmbiSense."""
 
 
 class PresenceX11Buddy(PresenceBuddyMixin, X11Buddy):
-    """X11/XWayland Buddy with Mochi Sense and unchanged drag behavior."""
+    """X11/XWayland Buddy with AmbiSense and unchanged drag behavior."""

--- a/src/mochi/quick_start.py
+++ b/src/mochi/quick_start.py
@@ -29,7 +29,7 @@ QUICK_START_SECTIONS = (
     ),
     QuickStartSection(
         "Ambient Reactions",
-        "Mochi Sense uses broad, privacy-reduced activity signals rather than the "
+        "AmbiSense uses broad, privacy-reduced activity signals rather than the "
         "content of what you type. Depending on what your desktop exposes, Mochi "
         "may respond with animations, behavior changes, or an occasional phrase.",
         (
@@ -62,7 +62,7 @@ QUICK_START_SECTIONS = (
         "You’re in Control",
         "The right-click menu lets you sleep or wake Mochi, toggle Edge roam, use "
         "Stay put to stop autonomous wandering, and close Mochi. More granular "
-        "Mochi Sense controls for speech bubbles, ambient reactions, and quiet mode "
+        "AmbiSense controls for speech bubbles, ambient reactions, and quiet mode "
         "currently live in Mochi Lab, which is a developer/testing surface.",
     ),
     QuickStartSection(

--- a/tests/test_presence_liveliness.py
+++ b/tests/test_presence_liveliness.py
@@ -15,7 +15,7 @@ class Clock:
         return self.value
 
 
-def test_default_presence_uses_lively_mochi_sense_profile():
+def test_default_presence_uses_lively_ambisense_profile():
     tuning = PresenceTuning()
     assert tuning.ambient_min_seconds == 20
     assert tuning.ambient_max_seconds == 60


### PR DESCRIPTION
## Summary

- rename the user-facing ambient-awareness system from **Mochi Sense** to **AmbiSense**
- update the README, GitHub Pages landing page, Quick Start copy, Mochi Lab label/tooltips, internal docstrings/comments, and the related test name
- add `docs/ambisense.md` to define the naming boundary

## Naming boundary

**AmbiSense** is the user-facing subsystem name.

The implementation keeps the existing internal `presence` architecture (`PresenceEngine`, `PresenceBuddyMixin`, etc.) so this remains a branding/name change rather than a risky code refactor.

## Scope

No intended behavior changes. No state-machine, timing, animation, packaging, privacy, or signal-handling logic changes.

## Verification

- review diff for naming-only changes
- run full pytest CI
